### PR TITLE
Configure database with POSTGRES_PASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     restart: always
     volumes:
       - db-data:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_PASSWORD=postgres
   pgweb:
     restart: always
     image: sosedoff/pgweb


### PR DESCRIPTION
Prior to adding the POSTGRES_PASSWORD environment variable, the database startup was failing with the following set of errors:

```
db_1       | Error: Database is uninitialized and superuser password is not specified.
db_1       |        You must specify POSTGRES_PASSWORD to a non-empty value for the
db_1       |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
db_1       |
db_1       |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
db_1       |        connections without a password. This is *not* recommended.
db_1       |
db_1       |        See PostgreSQL documentation about "trust":
db_1       |        https://www.postgresql.org/docs/current/auth-trust.html
```

Configuring POSTGRES_PASSWORD eliminates this error and enables the database to be initialized as expected.